### PR TITLE
aplicar costos de envío según la elección, al resumen de compra

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -73,19 +73,19 @@
       <p>TIPO DE ENVÍO</p>
 
       <label class="custom-radio">
-        <input type="radio" name="tipoEnvio" value="1">
+        <input type="radio" name="tipoEnvio" value="0.15" onchange="updateTotal()">
         Premium 2 a 5 días (15%)
         <span class="checkmark"></span>
       </label>
     
       <label class="custom-radio">
-        <input type="radio" name="tipoEnvio" value="2">
+        <input type="radio" name="tipoEnvio" value="0.07" onchange="updateTotal()">
         Express 5 a 8 días (7%)
         <span class="checkmark"></span>
       </label>
     
       <label class="custom-radio">
-        <input type="radio" name="tipoEnvio" value="3">
+        <input type="radio" name="tipoEnvio" value="0.05" onchange="updateTotal()">
         Standard 12 a 15 días (5%)
         <span class="checkmark"></span>
       </label>

--- a/js/cart.js
+++ b/js/cart.js
@@ -125,9 +125,10 @@ function updateTotal() {
         totalQuantity += (product.quantity || 1);
     });
 
-    // El costo de envío siempre es 0
-    const shippingCost = 0.00;
-    const totalWithShipping = subtotal + shippingCost;
+    // Obtener el valor del envío seleccionado
+    let shippingPercentage = parseFloat(document.querySelector('input[name="tipoEnvio"]:checked')?.value || 0);
+    let shippingCost = subtotal * shippingPercentage;
+    let totalWithShipping = subtotal + shippingCost;
 
     // Actualizar valores en el resumen
     document.getElementById('subtotal-value').textContent = subtotal.toFixed(2);
@@ -152,13 +153,16 @@ function removeFromCart(index) {
                     <p>Tu carrito está vacío</p>
                     <a href="products.html" class="btn btn-primary">Ir a Productos</a>
                 </div>`;
-            purchaseSummary.innerHTML = ''; // Eliminar el resumen de compra
-            
+                // Eliminar el contenido del resumen de compra
+                const purchaseSummary = document.getElementById('purchase-summary');
+                if (purchaseSummary) {
+                    purchaseSummary.innerHTML = ''; // Limpiar el resumen de compra
+                }            
          // Eliminar los datos de compra (asegurándote que el área de datos-compra también se vacíe)
-    const datosCompra = document.getElementById('datos-compra');
-    if (datosCompra) {
-        datosCompra.style.display = 'none';  // Esto oculta el contenedor de los datos de compra
-    }
+            const datosCompra = document.getElementById('datos-compra');
+            if (datosCompra) {
+                datosCompra.style.display = 'none';  // Esto oculta el contenedor de los datos de compra
+            }
         }
 
         


### PR DESCRIPTION
- Cambié "<input type="radio" name="tipoEnvio" value="1">" por: "<input type="radio" name="tipoEnvio" value="0.15" onchange="updateTotal()">", en cada radio para que se apliquen los valores de los porcentajes correspondientes y se aplique en la función updateTotal.
- Eliminé el valor fijo 0 de envío, ya que se debían aplicar los valores de los porcentajes (0.15, 0.07 y 0.05) según el envío que sea seleccionado, y definí el **costo de envío** que sea la multiplicación del subtotal por el porcentaje de envío (let shippingCost = subtotal * shippingPercentage;), luego para obtener el **costo total** con envío incluído, realicé la suma del subtotal y el costo de envío (let totalWithShipping = subtotal + shippingCost;).
- Cuando el carrito estaba vacío, las secciones de datos de envío y resumen de compra se superponían con el texto de carrito vacío, para esto agregué: 

> // Eliminar el contenido del resumen de compra
                const purchaseSummary = document.getElementById('purchase-summary');
                if (purchaseSummary) {
                    purchaseSummary.innerHTML = ''; // Limpiar el resumen de compra
                }   
Ya que no estaba aplicando el if, por no estar tomando la constante purchaseSummary.


